### PR TITLE
fix issue #54 by explicit conversion to float in get_price()

### DIFF
--- a/cryptop/cryptop.py
+++ b/cryptop/cryptop.py
@@ -67,9 +67,9 @@ def get_price(coin, curr=None):
 
     try:
         data_raw = r.json()['RAW']
-        return [(data_raw[c][curr]['PRICE'],
-                data_raw[c][curr]['HIGH24HOUR'],
-                data_raw[c][curr]['LOW24HOUR']) for c in coin.split(',') if c in data_raw.keys()]
+        return [(float(data_raw[c][curr]['PRICE']),
+                 float(data_raw[c][curr]['HIGH24HOUR']),
+                 float(data_raw[c][curr]['LOW24HOUR'])) for c in coin.split(',') if c in data_raw.keys()]
     except:
         sys.exit('Could not parse data')
 


### PR DESCRIPTION
Issue #54 was caused by the API calls after parsing the JSON data.
In some cases this resulted in strings instead of floats (what cryptop expects). Thus, the
TypeError was thrown due to float * str multiplication.