### PR TITLE
Correct usage of currency symbol

### DIFF
--- a/cryptop/config.ini
+++ b/cryptop/config.ini
@@ -11,6 +11,3 @@ field_length=12
 [api]
 currency=USD
 cache=10
-
-[locale]
-monetary=

--- a/cryptop/cryptop.py
+++ b/cryptop/cryptop.py
@@ -99,6 +99,13 @@ def conf_scr():
     curses.init_pair(3, banner_text, banner)
     curses.halfdelay(10)
 
+
+def locale_currency_str(val, max_length=0):
+    currency_str = locale.currency(val, grouping=True)
+    if max_length:
+        currency_str = currency_str[:max_length]
+    return currency_str
+
 def str_formatter(coin, val, held):
     '''Prepare the coin strings as per ini length/decimal place values'''
     max_length = CONFIG['theme'].getint('field_length', 13)
@@ -107,11 +114,11 @@ def str_formatter(coin, val, held):
     held_str = '{:>{},.8f}'.format(float(held), max_length)
     val_str = '{:>{},.{}f}'.format(float(held) * val[0], max_length, dec_place)
     return '  {:<5} {:>{}}  {} {:>{}} {:>{}} {:>{}}'.format(coin,
-        locale.currency(val[0], grouping=True)[:max_length], avg_length,
+        locale_currency_str(val[0], max_length), avg_length,
         held_str[:max_length],
-        locale.currency(float(held) * val[0], grouping=True)[:max_length], avg_length,
-        locale.currency(val[1], grouping=True)[:max_length], avg_length,
-        locale.currency(val[2], grouping=True)[:max_length], avg_length)
+        locale_currency_str(float(held) * val[0], max_length), avg_length,
+        locale_currency_str(val[1], max_length), avg_length,
+        locale_currency_str(val[2], max_length), avg_length)
 
 def write_scr(stdscr, wallet, y, x):
     '''Write text and formatting to screen'''
@@ -144,7 +151,7 @@ def write_scr(stdscr, wallet, y, x):
 
     if y > len(coinl) + 3:
         stdscr.addnstr(y - 2, 0, 'Total Holdings: {:10}    '
-            .format(locale.currency(total, grouping=True)), x, curses.color_pair(3))
+            .format(locale_currency_str(total)), x, curses.color_pair(3))
         stdscr.addnstr(y - 1, 0,
             '[A] Add/update coin [R] Remove coin [S] Sort [C] Cycle sort [0\Q]Exit', x,
             curses.color_pair(2))

--- a/cryptop/cryptop.py
+++ b/cryptop/cryptop.py
@@ -109,16 +109,25 @@ def locale_currency_str(val, max_length=0):
 def str_formatter(coin, val, held):
     '''Prepare the coin strings as per ini length/decimal place values'''
     max_length = CONFIG['theme'].getint('field_length', 13)
-    dec_place = CONFIG['theme'].getint('dec_places', 2)
     avg_length = CONFIG['theme'].getint('dec_places', 2) + 10
     held_str = '{:>{},.8f}'.format(float(held), max_length)
-    val_str = '{:>{},.{}f}'.format(float(held) * val[0], max_length, dec_place)
-    return '  {:<5} {:>{}}  {} {:>{}} {:>{}} {:>{}}'.format(coin,
-        locale_currency_str(val[0], max_length), avg_length,
-        held_str[:max_length],
-        locale_currency_str(float(held) * val[0], max_length), avg_length,
-        locale_currency_str(val[1], max_length), avg_length,
-        locale_currency_str(val[2], max_length), avg_length)
+
+    price, high, low = val
+    price_str = locale_currency_str(price, max_length)
+    high_str = locale_currency_str(high, max_length)
+    low_str = locale_currency_str(low, max_length)
+    value_str = locale_currency_str(float(held) * price, max_length)
+
+    str = '  {coin:<5} {price:>{avg_length}}  {held_str} {value:>{avg_length}} {high:>{avg_length}} {low:>{avg_length}}'
+
+    return str.format( coin=coin,
+                       price=price_str,
+                       held_str=held_str[:max_length],
+                       value=value_str,
+                       high=high_str,
+                       low=low_str,
+                       avg_length=avg_length )
+
 
 def write_scr(stdscr, wallet, y, x):
     '''Write text and formatting to screen'''

--- a/cryptop/cryptop.py
+++ b/cryptop/cryptop.py
@@ -6,7 +6,6 @@ import shutil
 import configparser
 import json
 import pkg_resources
-import locale
 from babel import numbers
 
 import requests
@@ -279,7 +278,6 @@ def main():
 
     global CONFIG
     CONFIG = read_configuration(CONFFILE)
-    locale.setlocale(locale.LC_MONETARY, CONFIG['locale'].get('monetary', ''))
 
     requests_cache.install_cache(cache_name='api_cache', backend='memory',
         expire_after=int(CONFIG['api'].get('cache', 10)))

--- a/cryptop/cryptop.py
+++ b/cryptop/cryptop.py
@@ -7,6 +7,7 @@ import configparser
 import json
 import pkg_resources
 import locale
+from babel import numbers
 
 import requests
 import requests_cache
@@ -101,7 +102,8 @@ def conf_scr():
 
 
 def locale_currency_str(val, max_length=0):
-    currency_str = locale.currency(val, grouping=True)
+    currency = CONFIG['api'].get('currency', 'USD')
+    currency_str = numbers.format_currency( val, currency )
     if max_length:
         currency_str = currency_str[:max_length]
     return currency_str

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 requests_cache
+babel

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     packages=find_packages(),
-    install_requires=['requests', 'requests_cache'],
+    install_requires=['requests', 'requests_cache', 'babel'],
     package_data={'cryptop': ['config.ini']},
     entry_points = {
         'console_scripts': ['cryptop = cryptop.cryptop:main'],


### PR DESCRIPTION
cryptop use the currency symbol of the machine locale.
It means that, for example, if you have a french local `fr_FR.UTF-8`, even if you set the `currency` option to `USD` in your config file, you will have the `€` currency symbol in cryptop.

We can't use anymore the `locale` package because it need locale to be installed to use a specific currency. User don't wan't to install chinese local to have cryptop value in `¥`.

I use the `babel` library to get all currency symbol without installing locale.